### PR TITLE
Removed gulp dependencies

### DIFF
--- a/tasks/backstop.js
+++ b/tasks/backstop.js
@@ -64,22 +64,16 @@ module.exports = function(grunt) {
       };
 
       this.run_tests = function(backstop_path, test_path, cb) {
-        child_process.exec('gulp test', {cwd: backstop_path}, function(err, stdout, stderr) {
+        child_process.exec('npm run test', {cwd: backstop_path}, function(err, stdout, stderr) {
           this.log(err, stdout, stderr);
-          child_process.exec('cp -rf ./bitmaps_test ' + test_path, {cwd: backstop_path}, function(err, stdout, stderr) {
-            this.log(err, stdout, stderr);
-            cb(true);
-          }.bind(this));
+          cb(true);
         }.bind(this));
       };
 
       this.create_references = function(backstop_path, test_path, cb) {
-        child_process.exec('gulp reference', {cwd: backstop_path}, function(err, stdout, stderr) {
+        child_process.exec('npm run reference', {cwd: backstop_path}, function(err, stdout, stderr) {
           this.log(err, stdout, stderr);
-          child_process.exec('cp -rf ./bitmaps_reference ' + test_path, {cwd: backstop_path}, function(err, stdout, stderr) {
-            this.log(err, stdout, stderr);
-            cb(true);
-          }.bind(this));
+          cb(true);
         }.bind(this));
       };
 


### PR DESCRIPTION
With Backstop version 1.1, all Gulp commands have been migrated to npm run <command> format for better compatibility.
